### PR TITLE
refactor: migrate middleware to proxy for locale detection and routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - Main locale `generateMetadata` now sets `metadataBase` and locale-root canonical alternates in `app/[locale]/layout.tsx`
 - Introduced shared `SITE_URL` config in `lib/config.ts` and reused it in canonical metadata helpers
+- Migrated Next.js routing entry from `middleware.ts` to `proxy.ts` to align with Next.js 16 file convention deprecation
+- Renamed default export from `middleware` to `proxy` while preserving `next-intl` i18n routing and `x-pathname` header behavior
+- Updated related references in tests and documentation to use `proxy.ts`
 
 ## [1.4.4] - 2026-05-10
 

--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ apps/web/
 │   ├── pages/       # Page tests
 │   ├── views/       # View tests
 │   └── test-utils.tsx # Custom render with i18n context
-├── middleware.ts    # Locale detection and routing
+├── proxy.ts         # Locale detection and routing
 ├── public/          # Static assets and icons
 └── ...
 ```

--- a/__tests__/proxy.test.ts
+++ b/__tests__/proxy.test.ts
@@ -8,14 +8,14 @@ vi.mock('next-intl/middleware', () => ({
   default: mockCreateMiddleware,
 }));
 
-describe('middleware', () => {
+describe('proxy', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   it('should create middleware with routing configuration', async () => {
-    // Import the middleware after mocking
-    await import('../middleware');
+    // Import the proxy after mocking
+    await import('../proxy');
 
     expect(mockCreateMiddleware).toHaveBeenCalledWith(routing);
     expect(mockCreateMiddleware).toHaveBeenCalledTimes(1);
@@ -27,14 +27,14 @@ describe('middleware', () => {
   });
 
   it('should have correct matcher configuration', async () => {
-    const middlewareModule = await import('../middleware');
+    const middlewareModule = await import('../proxy');
 
     expect(middlewareModule.config).toBeDefined();
     expect(middlewareModule.config.matcher).toBe('/((?!api|_next|_vercel|.*\\..*).*)');
   });
 
   it('should exclude api routes from middleware', async () => {
-    const middlewareModule = await import('../middleware');
+    const middlewareModule = await import('../proxy');
 
     expect(middlewareModule.config.matcher).toContain('(?!api|_next|_vercel');
 

--- a/i18n/request.ts
+++ b/i18n/request.ts
@@ -100,7 +100,7 @@ async function loadMessages(locale: string, namespaces: string[]) {
 }
 
 export default getRequestConfig(async ({ requestLocale }) => {
-  // Get the current pathname from headers set by middleware
+  // Get the current pathname from headers set by proxy
   const headersList = await headers();
   const pathname = headersList.get('x-pathname') || '/';
 

--- a/proxy.ts
+++ b/proxy.ts
@@ -5,7 +5,7 @@ import { routing } from './i18n/routing';
 
 const handleI18nRouting = createMiddleware(routing);
 
-export default function middleware(request: NextRequest) {
+export default function proxy(request: NextRequest) {
   const response = handleI18nRouting(request);
 
   // Add the pathname to the response headers for use in i18n/request.ts


### PR DESCRIPTION
## Contexte
Next.js 16.2.4 déprécie la convention [middleware.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) au profit de proxy.ts.
Cette PR migre le point d’entrée de routage i18n pour supprimer le warning de dépréciation tout en conservant le comportement existant (next-intl + header x-pathname).

## Changements
- Renommage du fichier middleware.ts vers [proxy.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).
- Renommage de la fonction exportée par défaut :
middleware(request) → proxy(request) dans [proxy.ts:8](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).
- Conservation du comportement i18n existant via next-intl/middleware dans [proxy.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).
- Conservation de l’ajout du header x-pathname dans [proxy.ts:11](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).
- Mise à jour des tests pour importer le nouveau fichier dans tests/middleware.test.ts.
- Mise à jour du commentaire de contexte dans [request.ts:103](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).
- Mise à jour de la documentation de structure dans [README.md:359](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).
- Vérification de la config Next.js : aucun usage de skipMiddlewareUrlNormalize dans [next.config.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), donc aucun changement nécessaire.

## Vérifications réalisées
- Build OK avec yarn build.
- Le warning de dépréciation middleware n’apparaît plus en mode dev.
- Routage i18n validé sur plusieurs routes localisées :
    - /en → 200
    - /fr/a-propos → 200
- Header x-pathname présent et correct :
    - x-pathname: /en
    - x-pathname: /fr/a-propos
- Test ciblé OK : tests/middleware.test.ts (4/4).

## Impact
- Aucun changement fonctionnel attendu côté utilisateur.
- Migration pure de convention Next.js pour compatibilité future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture documentation and changelog to reflect infrastructure organization changes.

* **Chores**
  * Refactored internal routing infrastructure and updated corresponding test references to maintain code alignment.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mitchnsun/gocosmic/pull/57)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->