### PR TITLE
[FEAT] New Fonts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [1.5.1] - 2026-05-14
+## [1.5.1] - 2026-05-15
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-- Replace Poppins font with Space Grotesk across the app
+- Split typography into two font roles: Space Grotesk (headings, header and footer links) and Inter (body text)
 
 ## [1.5.0] - 2026-05-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.5.1] - 2026-05-14
+
+### Changed
+
+- Replace Poppins font with Space Grotesk across the app
+
 ## [1.5.0] - 2026-05-14
 
 ### Added

--- a/__tests__/pages/LocaleLayout.test.tsx
+++ b/__tests__/pages/LocaleLayout.test.tsx
@@ -11,8 +11,8 @@ import { SITE_URL } from '@/lib/config';
 
 // Mock Next.js modules
 vi.mock('next/font/google', () => ({
-  Poppins: () => ({
-    className: 'mocked-poppins-font',
+  Space_Grotesk: () => ({
+    className: 'mocked-space-grotesk-font',
   }),
 }));
 
@@ -139,7 +139,7 @@ describe('LocaleLayout', () => {
       // Check body styling
       const body = layout.props.children;
       expect(body.type).toBe('body');
-      expect(body.props.className).toContain('mocked-poppins-font');
+      expect(body.props.className).toContain('mocked-space-grotesk-font');
       expect(body.props.className).toContain('bg-slate-950');
     });
 
@@ -173,7 +173,7 @@ describe('LocaleLayout', () => {
       // Check body styling
       const body = layout.props.children;
       expect(body.type).toBe('body');
-      expect(body.props.className).toContain('mocked-poppins-font');
+      expect(body.props.className).toContain('mocked-space-grotesk-font');
       expect(body.props.className).toContain('bg-slate-950');
     });
 

--- a/__tests__/pages/LocaleLayout.test.tsx
+++ b/__tests__/pages/LocaleLayout.test.tsx
@@ -12,7 +12,10 @@ import { SITE_URL } from '@/lib/config';
 // Mock Next.js modules
 vi.mock('next/font/google', () => ({
   Space_Grotesk: () => ({
-    className: 'mocked-space-grotesk-font',
+    variable: 'mock-font-display',
+  }),
+  Inter: () => ({
+    variable: 'mock-font-body',
   }),
 }));
 
@@ -136,11 +139,14 @@ describe('LocaleLayout', () => {
       expect(layout.type).toBe('html');
       expect(layout.props.lang).toBe('en');
 
-      // Check body styling
+      // html carries the font variables
+      expect(layout.props.className).toContain('mock-font-display');
+      expect(layout.props.className).toContain('mock-font-body');
+
+      // body only carries the background
       const body = layout.props.children;
       expect(body.type).toBe('body');
-      expect(body.props.className).toContain('mocked-space-grotesk-font');
-      expect(body.props.className).toContain('bg-slate-950');
+      expect(body.props.className).toBe('bg-slate-950');
     });
 
     it('should call notFound for invalid locale', async () => {
@@ -170,11 +176,14 @@ describe('LocaleLayout', () => {
       expect(layout.type).toBe('html');
       expect(layout.props.lang).toBe('en');
 
-      // Check body styling
+      // html carries the font variables
+      expect(layout.props.className).toContain('mock-font-display');
+      expect(layout.props.className).toContain('mock-font-body');
+
+      // body only carries the background
       const body = layout.props.children;
       expect(body.type).toBe('body');
-      expect(body.props.className).toContain('mocked-space-grotesk-font');
-      expect(body.props.className).toContain('bg-slate-950');
+      expect(body.props.className).toBe('bg-slate-950');
     });
 
     it('should handle different locales in HTML lang attribute', async () => {

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -1,6 +1,6 @@
 import { Analytics } from '@vercel/analytics/next';
 import type { Metadata } from 'next';
-import { Space_Grotesk } from 'next/font/google';
+import { Inter, Space_Grotesk } from 'next/font/google';
 import { notFound } from 'next/navigation';
 import { hasLocale, NextIntlClientProvider } from 'next-intl';
 import { getTranslations } from 'next-intl/server';
@@ -16,6 +16,13 @@ import { getOgImages } from '@/lib/og';
 const spaceGrotesk = Space_Grotesk({
   subsets: ['latin'],
   weight: ['300', '400', '500', '600', '700'],
+  variable: '--font-display',
+});
+
+const inter = Inter({
+  subsets: ['latin'],
+  weight: ['300', '400', '500', '600', '700'],
+  variable: '--font-body',
 });
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }): Promise<Metadata> {
@@ -67,8 +74,8 @@ export default async function LocaleLayout({
   }
 
   return (
-    <html lang={locale || 'en'}>
-      <body className={`${spaceGrotesk.className} bg-slate-950`}>
+    <html lang={locale || 'en'} className={`${spaceGrotesk.variable} ${inter.variable}`}>
+      <body className="bg-slate-950">
         <NextIntlClientProvider>
           <Header />
           <div className="mt-16">{children}</div>

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -1,6 +1,6 @@
 import { Analytics } from '@vercel/analytics/next';
 import type { Metadata } from 'next';
-import { Poppins } from 'next/font/google';
+import { Space_Grotesk } from 'next/font/google';
 import { notFound } from 'next/navigation';
 import { hasLocale, NextIntlClientProvider } from 'next-intl';
 import { getTranslations } from 'next-intl/server';
@@ -13,9 +13,9 @@ import { routing } from '@/i18n/routing';
 import { SITE_URL } from '@/lib/config';
 import { getOgImages } from '@/lib/og';
 
-const poppins = Poppins({
+const spaceGrotesk = Space_Grotesk({
   subsets: ['latin'],
-  weight: ['100', '300', '400', '500', '700', '800'],
+  weight: ['300', '400', '500', '600', '700'],
 });
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }): Promise<Metadata> {
@@ -68,7 +68,7 @@ export default async function LocaleLayout({
 
   return (
     <html lang={locale || 'en'}>
-      <body className={`${poppins.className} bg-slate-950`}>
+      <body className={`${spaceGrotesk.className} bg-slate-950`}>
         <NextIntlClientProvider>
           <Header />
           <div className="mt-16">{children}</div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,17 +1,17 @@
-@import "tailwindcss";
+@import 'tailwindcss';
 
 @theme {
-  --color-aerospace: #FF4F00;
-  --color-chocolate: #58111A;
-  --color-cosmic-latte: #FFF8E7;
-  --color-ghost: #F8F8FF;
-  --color-jungle: #29AB87;
-  --color-misty-rose: #FFE4E1;
-  --color-outer-space: #414A4C;
-  --color-royal: #7851A9;
-  --color-space: #1E2952;
-  --font-display: 'Space Grotesk', sans-serif;
-  --font-body: 'Inter', sans-serif;
+  --color-aerospace: #ff4f00;
+  --color-chocolate: #58111a;
+  --color-cosmic-latte: #fff8e7;
+  --color-ghost: #f8f8ff;
+  --color-jungle: #29ab87;
+  --color-misty-rose: #ffe4e1;
+  --color-outer-space: #414a4c;
+  --color-royal: #7851a9;
+  --color-space: #1e2952;
+  --font-display: 'Space Grotesk', system-ui, sans-serif;
+  --font-body: 'Inter', system-ui, sans-serif;
 }
 
 :root {

--- a/app/globals.css
+++ b/app/globals.css
@@ -10,8 +10,28 @@
   --color-outer-space: #414A4C;
   --color-royal: #7851A9;
   --color-space: #1E2952;
+  --font-display: 'Space Grotesk', sans-serif;
+  --font-body: 'Inter', sans-serif;
 }
 
 :root {
   --header-height: 64px;
+}
+
+body {
+  font-family: var(--font-body);
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: var(--font-display);
+}
+
+header nav a,
+footer a {
+  font-family: var(--font-display);
 }

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -11,3 +11,13 @@ This file records lessons learned from past mistakes and corrections made during
 ---
 
 <!-- Add new lessons below, grouped by topic -->
+
+## CSS / TailwindCSS 4
+
+### `--font-display` and `--font-body` must be declared in `@theme`
+
+Despite a PR review suggesting that hardcoding `--font-display` and `--font-body` inside `@theme` risks overriding the next/font-generated CSS variables (due to cascade order), **removing them from `@theme` breaks the styles**: Tailwind 4 reads font variables from `@theme` at build time and does not fall back to runtime CSS variables set by `next/font` on `<html>`.
+
+**Root cause:** Tailwind 4's `@theme` is processed statically. If `--font-display` / `--font-body` are absent from `@theme`, the generated utility classes that reference them (e.g. `font-display`) simply don't resolve — even when `next/font` injects the same variable names at runtime via class on `<html>`.
+
+**Correct pattern:** Keep the literal `font-family` strings in `@theme` so Tailwind can generate its utilities. Optionally add fallbacks at the consumption site (`font-family: var(--font-body, system-ui, sans-serif)`), but do **not** remove the `@theme` declarations.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gocosmic",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "type": "module",
   "private": true,
   "scripts": {


### PR DESCRIPTION
Space Grotesk & Inter instead of Poppins

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changed**
  * Updated typography to a two-font system: headings, header/footer links use Space Grotesk; body text uses Inter. Global styles reference font tokens.
* **Tests**
  * Updated layout tests to expect new font classes and adjusted body styling.
* **Chores**
  * Bumped project version to 1.5.1 and added changelog entry.
* **Documentation**
  * Added guidance on declaring font tokens for Tailwind CSS 4.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mitchnsun/gocosmic/pull/64)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->